### PR TITLE
Update middleware dependency (I)

### DIFF
--- a/src/lt/plugins/cljrefactor/middleware.cljs
+++ b/src/lt/plugins/cljrefactor/middleware.cljs
@@ -7,24 +7,24 @@
 (defn create-op [params]
   (str
    "(do
-     (require 'refactor-nrepl.client)
      (require 'clojure.tools.nrepl)
+     (let [port (-> \".nrepl-port\" slurp Integer/parseInt)]
      (clojure.tools.nrepl/message
-       (clojure.tools.nrepl/client (refactor-nrepl.client/connect) 10000)\n"
-       (pr-str params) "))"))
+       (clojure.tools.nrepl/client (clojure.tools.nrepl/connect :port port :host \"localhost\") 10000)\n"
+       (pr-str params) ")))"))
 
 
 (defn create-ns-op [ed params]
   (let [filename (-> @ed :info :path)]
     (str
      "(do
-     (require 'refactor-nrepl.client)
      (require 'clojure.tools.nrepl)
      (require 'lighttable.nrepl.eval)\n"
-     "(clojure.tools.nrepl/message
-     (clojure.tools.nrepl/client (refactor-nrepl.client/connect) 10000)\n"
+     "(let [port (-> \".nrepl-port\" slurp Integer/parseInt)]
+     (clojure.tools.nrepl/message
+     (clojure.tools.nrepl/client (clojure.tools.nrepl/connect :port port :host \"localhost\") 10000)\n"
      (str (s/join "" (drop-last (pr-str params))) " :ns "
-          "(lighttable.nrepl.eval/file->ns \"" filename "\")}") "))")))
+          "(lighttable.nrepl.eval/file->ns \"" filename "\")}") ")))")))
 
 
 (defn extract-result-group [res k]
@@ -44,6 +44,3 @@
                  (merge
                   (into {} (map #(hash-map % (extract-result-group-single res %)) singles))
                   (into {} (map #(hash-map % (extract-result-group res %)) multiples))))])))
-
-
-

--- a/src/lt/plugins/cljrefactor/usages.cljs
+++ b/src/lt/plugins/cljrefactor/usages.cljs
@@ -64,7 +64,8 @@
 (defn usages->items [usages]
   (vec (->> usages
             (map (fn [{x :occurrence}]
-                   (apply hash-map (cljs.reader/read-string x)))))))
+                    (let [r (cljs.reader/read-string x)]
+                      (if (map? r) r (apply hash-map r))))))))
 
 (defn items->view [items]
   (->> items


### PR DESCRIPTION
I've been trying to get this plugin working with Clojure 1.9. After lots of fiddling it seems I need to update both dependencies `refactor-nrepl` to `2.4.0-SNAPSHOT` and `cider/cider-nrepl` to `0.18.0-SNAPSHOT`. (Due to some hiccup their non-SNAPSHOT versions aren't mutually compatible recently, from what I found in github issues clojure-emacs/refactor-nrepl#221 )

However this in turn triggers more error on this side. I've made the following changes so far:

1. Auto-Complete doesn't work (which is catastrophic for me since this actually *replace* LT's built-in and the disable escape-hatch never worked for me). Peeping at nrepl traffic, and then doing some archaeology on `refactor-nrepl` shows that clojure-emacs/refactor-nrepl@af9a236 removed the client namespace. Also, this plugin currently send some bashed together string through the nrepl for the other side to evaluate, which called this. So I copied the code from the `refactor-nrepl` repo and inlined it.

2. After update, "Find Usage" gets broken. Repeat the process, took me some squinting of my eyes to find out that the return format has subtly changed. In the old version the map is presented instead as a list alternating between key and value which is corrected in new version, e.g. `(:line-beg 3 :line-end 4)` vs `{:line-beg 3 :line-end 4}`. I traced out the code in this plugin that "fixed" this format, and changed it to detect whether it is a map or not (in order to preserve backward-compatibility, if there is such a thing).


